### PR TITLE
Remove Haml dependency, fixes #3

### DIFF
--- a/app/views/twitter_bootstrap_form_for/_input.html.haml
+++ b/app/views/twitter_bootstrap_form_for/_input.html.haml
@@ -1,6 +1,0 @@
-= form.div_wrapper attribute, :class => 'clearfix' do
-  = form.label attribute, label if label
-  .input{:class => add_on}
-    = yield
-    %span.help-inline= form.errors_for(attribute) if form.errors_on?(attribute)
-    = capture &block if block.present?

--- a/app/views/twitter_bootstrap_form_for/_inputs.html.haml
+++ b/app/views/twitter_bootstrap_form_for/_inputs.html.haml
@@ -1,5 +1,0 @@
-%fieldset
-  - if legend.present?
-    %legend= legend
-  
-  = yield

--- a/app/views/twitter_bootstrap_form_for/_toggle.html.haml
+++ b/app/views/twitter_bootstrap_form_for/_toggle.html.haml
@@ -1,4 +1,0 @@
-%li
-  %label{:for => id}
-    = yield
-    %span= label

--- a/app/views/twitter_bootstrap_form_for/_toggles.html.haml
+++ b/app/views/twitter_bootstrap_form_for/_toggles.html.haml
@@ -1,6 +1,0 @@
-.clearfix
-  %label= label
-
-  .input
-    %ul.inputs-list
-      = yield

--- a/lib/twitter_bootstrap_form_for/railtie.rb
+++ b/lib/twitter_bootstrap_form_for/railtie.rb
@@ -5,6 +5,5 @@ class TwitterBootstrapFormFor::Railtie < Rails::Railtie
   initializer 'twitter_bootstrap_form_for.initialize',
     :after => :after_initialize do
     ActionView::Base.send :include, TwitterBootstrapFormFor::FormHelpers
-    ActionController::Base.append_view_path Pathname.new(__FILE__).join('../../../app/views')
   end
 end

--- a/twitter_bootstrap_form_for.gemspec
+++ b/twitter_bootstrap_form_for.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'rails', '~> 3'
-  s.add_dependency 'haml',  '~> 3'
   # TODO: uncomment the next line
   #  s.add_dependency 'twitter-bootstrap', '~> 1.3'
 end


### PR DESCRIPTION
Haml templates are rewritten in code. Haml dependency is removed

This also fixes a problem i had when using `inputs` and `actions` in an erb template.
