### PR TITLE
Add support for passing html options to #inputs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,7 +21,7 @@ Just Rails. But you were going to use that anyway, weren't you?
 = twitter_bootstrap_form_for @user do |user|
 
   / wraps a section in a fieldset with the provided legend text
-  = user.inputs 'Sign up' do
+  = user.inputs 'Sign up', :html => {:class => "sign_up"} do
 
     / generates a standard email field
     = user.email_field :email, :placeholder => 'me@example.com'

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -28,12 +28,12 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # Wraps the contents of the block passed in a fieldset with optional
   # +legend+ text.
   #
-  def inputs(legend = nil, &block)
+  def inputs(legend = nil, options = {}, &block)
     # stash the old field_error_proc, then override it temporarily
     original_field_error_proc = template.field_error_proc
     template.field_error_proc = lambda {|html_tag, instance| html_tag }
 
-    template.content_tag(:fieldset) do
+    template.content_tag(:fieldset, options[:html]) do
       template.concat template.content_tag(:legend, legend) unless legend.nil?
       block.call
     end


### PR DESCRIPTION
We wanted to add class names to our fieldsets, so we added a way to do it a la SimpleForm by passing in :fieldset_html

There are a lot of other places it could make sense to do the same thing.
