### PR TITLE
ruby 1.8 compat: fix hidden_field()

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -12,7 +12,7 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
     :select,
     *ActionView::Helpers::FormBuilder.instance_methods.grep(%r{
       _(area|field|select)$ # all area, field, and select methods
-    }mx)
+    }mx).map(&:to_sym)
   ]
 
   INPUTS.delete(:hidden_field)


### PR DESCRIPTION
`instance_methods` returns an array of strings in 1.8.
