### PR TITLE
Different solution to inline elements

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -39,7 +39,7 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # inside of here, and will not look correct unless they are.
   #
   def toggles(label = nil, &block)
-    div_wrapper_with_label do
+    div_wrapper_with_label(label) do
       template.content_tag(:ul, :class => "inputs-list") { block.call }
     end
   end

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -39,13 +39,14 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # inside of here, and will not look correct unless they are.
   #
   def toggles(label = nil, &block)
-    template.content_tag(:div, :class => 'clearfix') do
+    div_wrapper do
       template.concat template.content_tag(:label, label)
       template.concat template.content_tag(:div, :class => "input") {
         template.content_tag(:ul, :class => "inputs-list") { block.call }
       }
     end
   end
+  
 
   #
   # Wraps action buttons into their own styled container.
@@ -69,7 +70,7 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # to the supplied block.
   #
   def inline(label = nil, &block)
-    template.content_tag(:div, :class => 'clearfix') do
+    div_wrapper do
       template.concat template.content_tag(:label, label) if label.present?
       template.concat template.content_tag(:div, :class => 'input') {
         template.content_tag(:div, :class => 'inline-inputs') do
@@ -125,11 +126,15 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # id for the object's +attribute+. HTML options can be overridden by passing
   # an +options+ hash.
   #
-  def div_wrapper(attribute, options = {}, &block)
-    options[:id]    = _wrapper_id      attribute, options[:id]
-    options[:class] = _wrapper_classes attribute, options[:class], 'clearfix'
+  def div_wrapper(attribute=nil, options = {}, &block)
+    if attribute
+      options[:id]    = _wrapper_id      attribute, options[:id]
+      options[:class] = _wrapper_classes attribute, options[:class], 'clearfix'
 
-    template.content_tag :div, options, &block
+      template.content_tag :div, options, &block
+    else
+      template.content_tag :div, {:class=>'clearfix'}, &block
+    end
   end
 
   def error_span(attribute, options = {})

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -63,8 +63,9 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   end
 
   #
-  # Creates bootstrap wrapping before yielding a plain old rails builder
-  # to the supplied block.
+  # Creates bootstrap wrapping before yielding this builder instance.
+  # Yielding this instance is not necessary, but present for backwards compatability.
+  # 
   #
   def inline(label = nil, &block)
     div_wrapper_with_label(label) do
@@ -114,6 +115,8 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # id for the object's +attribute+. HTML options can be overridden by passing
   # an +options+ hash.
   #
+  # If no attribute is given, simply wraps contents in a clearfix container
+  #
   def div_wrapper(attribute=nil, options = {}, &block)
     if attribute
       options[:id]    = _wrapper_id      attribute, options[:id]
@@ -125,6 +128,10 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
     end
   end
   
+  #
+  # Wraps the field in the necessary wraper ('input by default) and adds the label
+  # If we are rendering inline, it simply yields
+  #
   def div_wrapper_with_label(label,attribute=nil, options={}, &block)
     if render_inline
       yield

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -69,12 +69,9 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   def inline(label = nil, &block)
     div_wrapper_with_label(label) do
       template.content_tag(:div, :class => 'inline-inputs') do
-        template.fields_for(
-          self.object_name,
-          self.object,
-          self.options.merge(:builder => ActionView::Base.default_form_builder),
-          &block
-        )
+        render_inline do
+          yield(self)
+        end
       end
     end
   end
@@ -129,14 +126,28 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   end
   
   def div_wrapper_with_label(label,attribute=nil, options={}, &block)
-    input_wrapper_class = options.delete(:input_wrapper_class) || 'input'
-    div_wrapper(attribute,options) do
-      if attribute
-        template.concat self.label(attribute, label)
-      else
-        template.concat template.content_tag(:label, label) if label.present?
+    if render_inline
+      yield
+    else
+      input_wrapper_class = options.delete(:input_wrapper_class) || 'input'
+      div_wrapper(attribute,options) do
+        if attribute
+          template.concat self.label(attribute, label)
+        else
+          template.concat template.content_tag(:label, label) if label.present?
+        end
+        template.concat template.content_tag(:div, {:class=>input_wrapper_class},&block)
       end
-      template.concat template.content_tag(:div, {:class=>input_wrapper_class},&block)
+    end
+  end
+  
+  def render_inline(&block)
+    if block.present?
+      @render_inline = true
+      yield
+      @render_inline = false
+    else
+      @render_inline
     end
   end
 

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -39,11 +39,8 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # inside of here, and will not look correct unless they are.
   #
   def toggles(label = nil, &block)
-    div_wrapper do
-      template.concat template.content_tag(:label, label)
-      template.concat template.content_tag(:div, :class => "input") {
-        template.content_tag(:ul, :class => "inputs-list") { block.call }
-      }
+    div_wrapper_with_label do
+      template.content_tag(:ul, :class => "inputs-list") { block.call }
     end
   end
   
@@ -70,18 +67,15 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # to the supplied block.
   #
   def inline(label = nil, &block)
-    div_wrapper do
-      template.concat template.content_tag(:label, label) if label.present?
-      template.concat template.content_tag(:div, :class => 'input') {
-        template.content_tag(:div, :class => 'inline-inputs') do
-          template.fields_for(
-            self.object_name,
-            self.object,
-            self.options.merge(:builder => ActionView::Base.default_form_builder),
-            &block
-          )
-        end
-      }
+    div_wrapper_with_label(label) do
+      template.content_tag(:div, :class => 'inline-inputs') do
+        template.fields_for(
+          self.object_name,
+          self.object,
+          self.options.merge(:builder => ActionView::Base.default_form_builder),
+          &block
+        )
+      end
     end
   end
 
@@ -91,14 +85,11 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
       label    = args.first.nil? ? '' : args.shift
       classes  = [ 'input' ]
       classes << ('input-' + options.delete(:add_on).to_s) if options[:add_on]
-
-      self.div_wrapper(attribute) do
-        template.concat self.label(attribute, label) if label
-        template.concat template.content_tag(:div, :class => classes.join(' ')) {
-          template.concat super(attribute, *(args << options))
-          template.concat error_span(attribute)
-          block.call if block.present?
-        }
+      
+      self.div_wrapper_with_label(label,attribute,:input_wrapper_class=>classes.join(' ')) do
+        template.concat super(attribute, *(args << options))
+        template.concat error_span(attribute)
+        block.call if block.present?
       end
     end
   end
@@ -134,6 +125,18 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
       template.content_tag :div, options, &block
     else
       template.content_tag :div, {:class=>'clearfix'}, &block
+    end
+  end
+  
+  def div_wrapper_with_label(label,attribute=nil, options={}, &block)
+    input_wrapper_class = options.delete(:input_wrapper_class) || 'input'
+    div_wrapper(attribute,options) do
+      if attribute
+        template.concat self.label(attribute, label)
+      else
+        template.concat template.content_tag(:label, label) if label.present?
+      end
+      template.concat template.content_tag(:div, {:class=>input_wrapper_class},&block)
     end
   end
 


### PR DESCRIPTION
Howdy,
  I saw that you just fixed the attribute nesting error, but I was working on another alternative before you pushed those changes.  Probably should have said something, but, you know how that goes sometimes.
  Anyway, one of the problems for me, at least, with returning a default rails builder is that I have subclasses your TwitterBootstrapFormFor::FormBuilder form builder so that I can do nifty things like automatically marking fields as required, populating dropdowns, etc.  In inline forms, I lose all the stuff that I do in my subclassed form builder because it returns the default builder, which is no fun for me.  Instead, I have it just yield the current instance of the form builder class that way we still have access to all the same nifty things from the form builder we are using.
  So, ya, there you go.  Let me know what you think.
