### PR TITLE
Passing options to toggle wrapper

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -95,11 +95,8 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
       target  = self.object_name.to_s + '_' + attribute.to_s
 
       template.content_tag(:li) do
-        template.concat template.content_tag(:label, :for => target) {
-          template.concat super(attribute, *args)
-          template.concat ' ' # give the input and span some room
-          template.concat template.content_tag(:span, label)
-        }
+        template.concat super(attribute, *args)
+        template.concat label(attribute)
       end
     end
   end

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -27,12 +27,14 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # Wraps the contents of the block passed in a fieldset with optional
   # +legend+ text.
   #
-  def inputs(legend = nil, &block)
+  def inputs(legend = nil, *args, &block)
+    options = args.extract_options!
+
     # stash the old field_error_proc, then override it temporarily
     original_field_error_proc = template.field_error_proc
     template.field_error_proc = ->(html_tag, instance) { html_tag }
 
-    template.content_tag(:fieldset) do
+    template.content_tag(:fieldset, options) do
       template.concat template.content_tag(:legend, legend) unless legend.nil?
       block.call
     end
@@ -45,8 +47,10 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # and the appropriate markup. All toggle buttons should be rendered
   # inside of here, and will not look correct unless they are.
   #
-  def toggles(label = nil, &block)
-    template.content_tag(:div, :class => "clearfix") do
+  def toggles(label = nil, *args, &block)
+    options = args.extract_options!
+    options[:class] = options.include?(:class) ? options[:class] + ' clearfix' : 'clearfix'
+    template.content_tag(:div, options) do
       template.concat template.content_tag(:label, label)
       template.concat template.content_tag(:div, :class => "input") {
         template.content_tag(:ul, :class => "inputs-list") { block.call }

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -10,7 +10,6 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   attr_reader :object_name
 
   INPUTS = [
-    :select,
     *ActionView::Helpers::FormBuilder.instance_methods.grep(%r{_area$}),
     *ActionView::Helpers::FormBuilder.instance_methods.grep(%r{_field$}),
     *ActionView::Helpers::FormBuilder.instance_methods.grep(%r{_select$}),
@@ -78,13 +77,18 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   INPUTS.each do |input|
     define_method input do |attribute, *args, &block|
       options  = args.extract_options!
+      if options[:skip]
+        options.delete(:skip)
+        return super(attribute, options)
+      end
+
       label    = args.first.nil? ? '' : args.shift
       classes  = [ 'input' ]
       classes << ('input-' + options.delete(:add_on).to_s) if options[:add_on]
 
       self.div_wrapper(attribute) do
         template.concat self.label(attribute, label) if label
-        template.concat template.content_tag(:div, :class => classes.join(' ')) {
+        template.concat template.content_tag(:div, :class => classes) {
           template.concat super(attribute, *(args << options))
           template.concat error_span(attribute)
           block.call if block.present?
@@ -111,7 +115,6 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # an +options+ hash.
   #
   def div_wrapper(attribute, options = {}, &block)
-    options[:id]    = _wrapper_id      attribute, options[:id]
     options[:class] = _wrapper_classes attribute, options[:class], 'clearfix'
 
     template.content_tag :div, options, &block
@@ -135,18 +138,6 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   end
 
   private
-
-  #
-  # Returns an HTML id to uniquely identify the markup around an input field.
-  # If a +default+ is provided, it uses that one instead.
-  #
-  def _wrapper_id(attribute, default = nil)
-    default || [
-      _object_name + _object_index,
-      _attribute_name(attribute),
-      'input'
-     ].join('_')
-  end
 
   #
   # Returns any classes necessary for the wrapper div around fields for
@@ -175,3 +166,4 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
     end.to_s
   end
 end
+

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -38,8 +38,10 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # and the appropriate markup. All toggle buttons should be rendered
   # inside of here, and will not look correct unless they are.
   #
-  def toggles(label = nil, &block)
-    template.content_tag(:div, :class => 'clearfix') do
+  def toggles(label = nil, *args, &block)
+    options = args.extract_options!
+    options[:class] = options.include?(:class) ? options[:class] + ' clearfix' : 'clearfix'
+    template.content_tag(:div, options) do
       template.concat template.content_tag(:label, label)
       template.concat template.content_tag(:div, :class => "input") {
         template.content_tag(:ul, :class => "inputs-list") { block.call }

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -91,12 +91,12 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
 
   TOGGLES.each do |toggle|
     define_method toggle do |attribute, *args, &block|
-      label   = args.first.nil? ? '' : args.shift
-      target  = self.object_name.to_s + '_' + attribute.to_s
+      label_for   = args.first.nil? ? label(attribute) : label(attribute, args.shift)
+      target      = self.object_name.to_s + '_' + attribute.to_s
 
       template.content_tag(:li) do
         template.concat super(attribute, *args)
-        template.concat label(attribute)
+        template.concat label_for
       end
     end
   end


### PR DESCRIPTION
I added the ability to pass additional `content_tag` options to the `toggles` method. Something like:

``` ruby
f.toggles 'Label', :class => 'my-toggles', :id => 'my-toggles' do
  ...
end
```
