### PR TITLE
Rails 3.2.0 undefined method `field_error_proc=' for #<TwitterBootstrapFormFor::FormBuilder> errors 

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_helpers.rb
+++ b/lib/twitter_bootstrap_form_for/form_helpers.rb
@@ -9,7 +9,7 @@ module TwitterBootstrapFormFor::FormHelpers
         options[:builder] = TwitterBootstrapFormFor::FormBuilder
 
         # call the original method with our overridden options
-        _override_field_error_proc do
+        custom_override_field_error_proc do
           send method, record, *(args << options), &block
         end
       end
@@ -18,13 +18,16 @@ module TwitterBootstrapFormFor::FormHelpers
 
   private
 
-  BLANK_FIELD_ERROR_PROC = lambda {|input, _| input }
+  BLANK_FIELD_ERROR_PROC = proc do |html_tag, instance_tag|
+    html_tag
+  end
 
-  def _override_field_error_proc
-    original_field_error_proc = self.field_error_proc
-    self.field_error_proc     = BLANK_FIELD_ERROR_PROC
+  def custom_override_field_error_proc(&block)
+    original_field_error_proc = ::ActionView::Base.field_error_proc
+    ::ActionView::Base.field_error_proc = BLANK_FIELD_ERROR_PROC
     yield
   ensure
-    self.field_error_proc     = original_field_error_proc
+    ::ActionView::Base.field_error_proc = original_field_error_proc
   end
+
 end


### PR DESCRIPTION
Whilst updating to rails v3.2.0 I noticed that my nested TwitterBootstrapFormFor stopped working - upon some investigation I noticed the references to self which stopped working after the upgrade.

As you can see I added the static references to ActionView::Base and this now appears to work correctly. 
I have tested within my code and would appreciate you looking into it further and considering adding this revision.

I have a little helper that builds the nested form inserted below so you can see how I call and found the issue.

def new_child_fields_template(form_builder, association, options = {})
  path = options[:path] || ""
  options[:object] ||= form_builder.object.class.reflect_on_association(association).klass.new
  options[:partial] ||= "shared/nested_model_form"
  options[:form_builder_local] ||= :f

  content_tag(:div, :id => "#{association}_fields", :style => "display: none") do
    form_builder.twitter_bootstrap_fields_for(association, options[:object], :child_index => "new_#{association}") do |f|
      render(:partial => options[:partial], :locals => {options[:form_builder_local] => f, :nested_object => path + association.to_s.singularize})
    end
  end
end

and I use it in the following manner:

= twitter_bootstrap_form_for @company do |f|
  = f.inputs '' do
    = f.text_field :name
    = new_child_fields_template(f, :branches, :path => 'common/')

The form allows you to enter a company name and the nested form part displays the branch form details.
For example details about a new company and its multiple branches. 

There are a little suite of helpers I can share with you if you want to incorporate for helpers but also understand how you want to keep this gem simple ;-)

Thanks
