### PR TITLE
Show error span for check_boxes but not radios

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -114,6 +114,11 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
           template.concat ' ' # give the input and span some room
           template.concat template.content_tag(:span, label)
         }
+        if toggle == :check_box
+          template.concat template.content_tag(:div, :class => "clearfix error") {
+            template.concat error_span(attribute)
+          } if errors_on?(attribute)
+        end
       end
     end
   end


### PR DESCRIPTION
Further details in the [issue 9 thread](https://github.com/stouset/twitter_bootstrap_form_for/issues/9). As I said there:

The clearfix does cause some margin but I think it looks fine. I have a screenshot here:

![Error](http://lukesaunderspublic.s3.amazonaws.com/bootstrap_cb_error.png)
