### PR TITLE
Fix class names on submit button

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -59,7 +59,7 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   # button.
   #
   def submit(value = nil, options = {})
-    options[:class] ||= 'btn primary'
+    options[:class] ||= 'btn btn-primary'
 
     super value, options
   end


### PR DESCRIPTION
Not sure if Bootstrap has changed the CSS class names recently, but this makes the primary button that lovely Twitter blue (by default, of course) instead of a dull grey.
