### PR TITLE
Fix radio button label

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -183,7 +183,7 @@ class TwitterBootstrapFormFor::FormControls < ActionView::Helpers::FormBuilder
   def radio_button(attribute, value, text = nil, options = {})
     klasses = _merge_classes 'radio', options.delete(:inline) && 'inline'
 
-    self.label(attribute, :class => klasses) do
+    self.label(attribute, :value => value, :class => klasses) do
       template.concat super(attribute, value, options)
       template.concat text || value.to_s.humanize.titleize
       yield if block_given?


### PR DESCRIPTION
The radio button label isn't being associated with the correct radio button because it needs to be passed the value too. This fix makes sure the value is provided to the label.
