### PR TITLE
Add label_html option to allow setting html attributes on the generated label

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -90,9 +90,10 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
       label    = args.first.nil? ? '' : args.shift
       classes  = [ 'input' ]
       classes << ('input-' + options.delete(:add_on).to_s) if options[:add_on]
+      label_html = options.delete(:label_html) || {}
 
       self.div_wrapper(attribute) do
-        template.concat self.label(attribute, label) if label
+        template.concat self.label(attribute, label, label_html) if label
         template.concat template.content_tag(:div, :class => classes.join(' ')) {
           template.concat super(attribute, *(args << options))
           template.concat error_span(attribute)


### PR DESCRIPTION
This lets you set specific html values for the label.

e.g.
= f.text_field :address_line1, 'Address line 1', label_html: { class:
"required" }

This adds the 'required' class to the generated label
