### PR TITLE
new option for low-verbosity horizontal forms

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,7 @@ Just Rails. But you were going to use that anyway, weren't you?
 
 ```haml
 / supports both vertical and horizontal forms
-= twitter_bootstrap_form_for @user, :html => { :class => 'form-horizontal'}  do |user|
+= twitter_bootstrap_form_for @user, :horizontal => true do |user|
 
   / wraps a section in a fieldset with the provided legend text
   = user.fieldset 'Sign up', :class => 'sign_up' do

--- a/lib/twitter_bootstrap_form_for/form_helpers.rb
+++ b/lib/twitter_bootstrap_form_for/form_helpers.rb
@@ -8,6 +8,15 @@ module TwitterBootstrapFormFor::FormHelpers
         options           = args.extract_options!
         options[:builder] = TwitterBootstrapFormFor::FormBuilder
 
+        if options[:horizontal]
+          if options[:html] && options[:html][:class]
+            options[:html][:class] << " form-horizontal"
+          else
+            options[:html] ||= {}
+            options[:html][:class] = "form-horizontal"
+          end
+        end
+
         # call the original method with our overridden options
         _override_field_error_proc do
           send method, record, *(args << options), &block


### PR DESCRIPTION
These changes make this:

```
twitter_bootstrap_form_for(@user, :horizontal => true) do |user|
```

equivalent to this:

```
twitter_bootstrap_form_for(@user, :html => {:class => "form-horizontal"}) do |user|
```
