### PR TITLE
Fix the inline help being invisible with addons

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -161,12 +161,12 @@ class TwitterBootstrapFormFor::FormControls < ActionView::Helpers::FormBuilder
       tag     = add_on.present? ? :div : :span
       classes = [ "input", add_on ].compact.join('-')
 
-      template.content_tag(tag, :class => classes) do
+      template.concat(template.content_tag(tag, :class => classes) do
         block.call if block.present? && add_on == :prepend
         template.concat super attribute, *(args << options)
         block.call if block.present? && add_on != :prepend
-        template.concat self.error_span(attribute) if self.errors_on?(attribute)
-      end
+      end)
+      template.concat(self.error_span(attribute)) if self.errors_on?(attribute)
     end
   end
 


### PR DESCRIPTION
when using the `:add_on => :prepend` option, the help-inline becomes invisible.

the following code will reproduce the issue when submitting the following form with an invalid value:

```
= twitter_bootstrap_form_for(@user, :html => { :class => "form-horizontal" }) do |user|
    = user.text_field :twitter_id, :add_on => :prepend do
      %span.add-on @
```

this is because the help-inline span wants to be at the same level as the input-prepend div, but it is within it. Attached code puts it in the correct place.
