### PR TITLE
add a price_field method

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -98,7 +98,10 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   #
   def price_field(attribute, *args)
     options = args.extract_options!
-    options = { :add_on => :prepend }.merge(options)
+    options[:add_on] ||= :prepend
+    options[:value]  ||= template.number_with_precision(
+                            object.read_attribute(attribute),
+                            :precision => 2) || 0
 
     text_field(attribute, *(args << options)) do
       template.concat template.content_tag(:span,

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -92,6 +92,21 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
     }.merge(options)
   end
 
+  #
+  # Renders a text field with the current locale's currency unit as a
+  # prepended add-on.
+  #
+  def price_field(attribute, *args)
+    options = args.extract_options!
+    options = { :add_on => :prepend }.merge(options)
+
+    text_field(attribute, *(args << options)) do
+      template.concat template.content_tag(:span,
+                           I18n.t('number.currency.format.unit').html_safe,
+                           :class => 'add-on')
+    end
+  end
+
   INPUTS.each do |input|
     define_method input do |attribute, *args, &block|
       options = args.extract_options!


### PR DESCRIPTION
Assuming we're in a `twitter_bootstrap_form_for` block with `user` as the block variable:

the attached code makes this:

```
= user.price_field :balance
```

equivalent to this:

```
= user.text_field :balance, :add_on => :prepend do
  %span.add-on= t('number.currency.format.unit').html_safe
```
