### PR TITLE
Add link_button helper method

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -72,6 +72,16 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   end
 
   #
+  # Renders a link with default classes to style it as a form button.
+  #
+  def link_button(value = nil, href = nil, options = {})
+    template.content_tag :a, value, {
+      :class => 'btn',
+      :href => href
+    }.merge(options)
+  end
+
+  #
   # Renders a button with default classes to style it as a form button.
   #
   def button(value = nil, options = {})


### PR DESCRIPTION
Just a small thing, so I can be like:

``` haml
= form.submit 'Save'
= form.link_button 'Cancel', posts_path
```

and have it generate

``` html
<button class="btn btn-primary" name="button" type="submit">
  Save
</button>

<a class="btn" href="/posts">
  Cancel
</a>
```
