### PR TITLE
Allow styling SELECT elements

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -87,6 +87,7 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
   INPUTS.each do |input|
     define_method input do |attribute, *args, &block|
       options  = args.extract_options!
+      html_options = options.delete(:html)
       label    = args.first.nil? ? '' : args.shift
       classes  = [ 'controls', 'input' ]
       classes << ('input-' + options.delete(:add_on).to_s) if options[:add_on]
@@ -95,7 +96,9 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
         template.concat self.label(attribute, label) if label
         template.concat template.content_tag(:div, :class => classes.join(' ')) {
           block.call if block.present? and classes.include?('input-prepend')
-          template.concat super(attribute, *(args << options))
+          final_args = args << options
+          final_args << html_options if html_options
+          template.concat super(attribute, *final_args)
           template.concat error_span(attribute)
           block.call if block.present? and classes.include?('input-append')
         }

--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -110,7 +110,7 @@ class TwitterBootstrapFormFor::FormBuilder < ActionView::Helpers::FormBuilder
     define_method toggle do |attribute, *args, &block|
       label       = args.first.nil? ? '' : args.shift
       target      = self.object_name.to_s + '_' + attribute.to_s
-      label_attrs = toggle == :check_box ? { :for => target } : {}
+      label_attrs = toggle == :check_box ? { :for => target, :class => "checkbox" } : { :class => "radio" }
 
       template.content_tag(:li) do
         template.concat template.content_tag(:label, label_attrs) {


### PR DESCRIPTION
By calling the helper with an `:html` key, we can style the underlying
select with a class:

```
<%= f.select :language, nil, html: { class: "span1" } %>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stouset/twitter_bootstrap_form_for/78)
<!-- Reviewable:end -->
