### PR TITLE
Fixing error message concatenation for an attribute when there is only 1...

### DIFF
--- a/lib/twitter_bootstrap_form_for/form_builder.rb
+++ b/lib/twitter_bootstrap_form_for/form_builder.rb
@@ -228,7 +228,8 @@ class TwitterBootstrapFormFor::FormControls < ActionView::Helpers::FormBuilder
   end
 
   def errors_for(attribute)
-    self.object.errors[attribute].try(:join, ', ')
+    errors = self.object.errors[attribute]
+    errors.respond_to?(:join) ? errors.join(', ') : errors
   end
 
   def errors_on?(attribute)


### PR DESCRIPTION
## ... error message

Currently when there's 1 error message per attribute, the :join is being invoked on a string trying to concatenate the error messages:
ActionView::TemplateError (undefined method `join' for "is not a number":String)
I.e.:

```
From: /Users/nz/.rvm/gems/ruby-1.8.7-p374@newui/bundler/gems/twitter_bootstrap_form_for-f5e5ef6273f9/lib/twitter_bootstrap_form_for/form_builder.rb @ line 231 TwitterBootstrapFormFor::FormControls#errors_for:
```

```
    230: def errors_for(attribute)
 => 231:   require 'pry'; binding.pry
    232:   self.object.errors[attribute].try(:join, ', ')
    233: end

[1] pry(#<TwitterBootstrapFormFor::FormControls>)> self.object.errors[attribute]
=> "is not a number"
```

---

This PR fixes that allowing 1 or more error messages per attribute.
